### PR TITLE
Add HTTP API for EliteLogs data

### DIFF
--- a/EliteLogs/pom.xml
+++ b/EliteLogs/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.elitelogs</groupId>
   <artifactId>EliteLogs</artifactId>
-  <version>1.1.0</version>
+  <version>1.2</version>
   <name>EliteLogs</name>
   <properties>
     <maven.compiler.source>8</maven.compiler.source>

--- a/EliteLogs/src/main/java/com/elitelogs/EliteLogsPlugin.java
+++ b/EliteLogs/src/main/java/com/elitelogs/EliteLogsPlugin.java
@@ -99,7 +99,7 @@ public class EliteLogsPlugin extends JavaPlugin {
         this.inspectorBootstrap = new InspectorBootstrap(this, lang);
         this.inspector = inspectorBootstrap.start();
 
-        this.apiServer = new ApiServer(this, logRouter, metricsCollector, sessionManager);
+        this.apiServer = new ApiServer(this, logRouter, metricsCollector, sessionManager, watchdog);
         apiServer.start();
 
         registerCommands();
@@ -160,7 +160,13 @@ public class EliteLogsPlugin extends JavaPlugin {
         getLogger().info(Lang.colorize(lang.formatModule("PlayerTracker", playerTracker != null)));
     }
 
-    public Lang lang(){ return lang; }
+    public Lang lang() {
+        return lang;
+    }
+
+    public Inspector inspector() {
+        return inspector;
+    }
 
     public void reloadApi() {
         if (apiServer != null) {

--- a/EliteLogs/src/main/java/com/elitelogs/EliteLogsPlugin.java
+++ b/EliteLogs/src/main/java/com/elitelogs/EliteLogsPlugin.java
@@ -1,5 +1,6 @@
 package com.elitelogs;
 
+import com.elitelogs.api.ApiServer;
 import com.elitelogs.bootstrap.DataDirectoryManager;
 import com.elitelogs.bootstrap.InspectorBootstrap;
 import com.elitelogs.bootstrap.ListenerRegistrar;
@@ -58,6 +59,7 @@ public class EliteLogsPlugin extends JavaPlugin {
     private InspectorBootstrap inspectorBootstrap;
     private Inspector inspector;
     private ListenerRegistrar listenerRegistrar;
+    private ApiServer apiServer;
 
     @Override
     public void onEnable() {
@@ -97,6 +99,9 @@ public class EliteLogsPlugin extends JavaPlugin {
         this.inspectorBootstrap = new InspectorBootstrap(this, lang);
         this.inspector = inspectorBootstrap.start();
 
+        this.apiServer = new ApiServer(this, logRouter, metricsCollector, sessionManager);
+        apiServer.start();
+
         registerCommands();
 
         dataDirectories.logLastSessionSummary();
@@ -115,6 +120,9 @@ public class EliteLogsPlugin extends JavaPlugin {
         }
         if (loggingBootstrap != null) {
             loggingBootstrap.shutdown();
+        }
+        if (apiServer != null) {
+            apiServer.stop();
         }
         getLogger().info(Lang.colorize(lang.get("plugin-disabled")));
     }
@@ -153,6 +161,12 @@ public class EliteLogsPlugin extends JavaPlugin {
     }
 
     public Lang lang(){ return lang; }
+
+    public void reloadApi() {
+        if (apiServer != null) {
+            apiServer.reload();
+        }
+    }
 
     // === Config auto-generate & self-heal ===
     private void writeDefaultConfigFile(File cfg) {
@@ -229,6 +243,13 @@ public class EliteLogsPlugin extends JavaPlugin {
             "metrics:",
             "  enabled: true",
             "  interval-seconds: 60",
+            "",
+            "api:",
+            "  enabled: false",
+            "  bind: \"127.0.0.1\"",
+            "  port: 9173",
+            "  auth-token: \"\"",
+            "  log-history: 250",
             "",
             "suppressor:",
             "  enabled: true",

--- a/EliteLogs/src/main/java/com/elitelogs/api/ApiLogBuffer.java
+++ b/EliteLogs/src/main/java/com/elitelogs/api/ApiLogBuffer.java
@@ -1,0 +1,82 @@
+package com.elitelogs.api;
+
+import com.elitelogs.logging.LogRouter;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+final class ApiLogBuffer implements LogRouter.SinkListener {
+    private final Map<String, CategoryBuffer> buffers = new ConcurrentHashMap<>();
+    private final AtomicInteger capacity = new AtomicInteger(250);
+
+    @Override
+    public void onLogged(String category, String line) {
+        if (category == null || line == null) {
+            return;
+        }
+        CategoryBuffer buffer = buffers.computeIfAbsent(category, key -> new CategoryBuffer());
+        buffer.add(line, capacity.get());
+    }
+
+    void setCapacity(int newCapacity) {
+        int normalized = Math.max(1, newCapacity);
+        capacity.set(normalized);
+        for (CategoryBuffer buffer : buffers.values()) {
+            buffer.trim(normalized);
+        }
+    }
+
+    int getCapacity() {
+        return capacity.get();
+    }
+
+    Set<String> getCategories() {
+        return Collections.unmodifiableSet(buffers.keySet());
+    }
+
+    List<String> getRecent(String category, int limit) {
+        CategoryBuffer buffer = buffers.get(category);
+        if (buffer == null) {
+            return Collections.emptyList();
+        }
+        return buffer.snapshot(limit);
+    }
+
+    private static final class CategoryBuffer {
+        private final Deque<String> deque = new ArrayDeque<>();
+
+        synchronized void add(String line, int capacity) {
+            deque.addLast(line);
+            trim(capacity);
+        }
+
+        synchronized void trim(int capacity) {
+            while (deque.size() > capacity) {
+                deque.removeFirst();
+            }
+        }
+
+        synchronized List<String> snapshot(int limit) {
+            if (limit <= 0 || deque.isEmpty()) {
+                return Collections.emptyList();
+            }
+            int size = Math.min(limit, deque.size());
+            List<String> copy = new ArrayList<>(size);
+            int skip = deque.size() - size;
+            int index = 0;
+            for (String value : deque) {
+                if (index++ >= skip) {
+                    copy.add(value);
+                }
+            }
+            return copy;
+        }
+    }
+}

--- a/EliteLogs/src/main/java/com/elitelogs/api/ApiServer.java
+++ b/EliteLogs/src/main/java/com/elitelogs/api/ApiServer.java
@@ -1,0 +1,460 @@
+package com.elitelogs.api;
+
+import com.elitelogs.EliteLogsPlugin;
+import com.elitelogs.compat.ServerCompat;
+import com.elitelogs.logging.LogRouter;
+import com.elitelogs.metrics.MetricsCollector;
+import com.elitelogs.reporting.SessionManager;
+import com.sun.net.httpserver.Headers;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import org.bukkit.configuration.ConfigurationSection;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.InetSocketAddress;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.StringTokenizer;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public final class ApiServer {
+    private static final String ATTR_RESPONSE_SENT = "elitelogs.responseSent";
+    private static final AtomicInteger THREAD_COUNTER = new AtomicInteger();
+
+    private final EliteLogsPlugin plugin;
+    private final MetricsCollector metricsCollector;
+    private final SessionManager sessionManager;
+    private final ApiLogBuffer logBuffer;
+    private final LogRouter logRouter;
+
+    private volatile HttpServer server;
+    private volatile ExecutorService executor;
+    private volatile ApiConfig activeConfig;
+
+    public ApiServer(EliteLogsPlugin plugin, LogRouter logRouter, MetricsCollector metricsCollector, SessionManager sessionManager) {
+        this.plugin = plugin;
+        this.metricsCollector = metricsCollector;
+        this.sessionManager = sessionManager;
+        this.logRouter = logRouter;
+        this.logBuffer = new ApiLogBuffer();
+        this.logRouter.addListener(logBuffer);
+    }
+
+    public synchronized void start() {
+        applyConfig();
+    }
+
+    public synchronized void stop() {
+        stopServer();
+    }
+
+    public synchronized void reload() {
+        applyConfig();
+    }
+
+    private void applyConfig() {
+        int history = plugin.getConfig().getInt("api.log-history", 250);
+        logBuffer.setCapacity(history);
+
+        boolean enabled = plugin.getConfig().getBoolean("api.enabled", false);
+        String bind = plugin.getConfig().getString("api.bind", "127.0.0.1");
+        int port = plugin.getConfig().getInt("api.port", 9173);
+        String tokenRaw = plugin.getConfig().getString("api.auth-token", "");
+        String token = tokenRaw != null && !tokenRaw.trim().isEmpty() ? tokenRaw.trim() : null;
+
+        if (!enabled) {
+            if (server != null) {
+                plugin.getLogger().info("[EliteLogs] API server disabled via config");
+            }
+            stopServer();
+            activeConfig = new ApiConfig(bind, port, token, false);
+            return;
+        }
+
+        ApiConfig desired = new ApiConfig(bind, port, token, true);
+        if (desired.equals(activeConfig) && server != null) {
+            return;
+        }
+
+        stopServer();
+        startServer(desired);
+    }
+
+    private void startServer(ApiConfig config) {
+        try {
+            HttpServer httpServer = HttpServer.create(new InetSocketAddress(config.bind, config.port), 0);
+            httpServer.createContext("/api/v1/status", exchange -> handleSafely(exchange, this::handleStatus));
+            httpServer.createContext("/api/v1/metrics", exchange -> handleSafely(exchange, this::handleMetrics));
+            httpServer.createContext("/api/v1/logs", exchange -> handleSafely(exchange, this::handleLogs));
+            ExecutorService exec = Executors.newCachedThreadPool(new ApiThreadFactory());
+            httpServer.setExecutor(exec);
+            httpServer.start();
+            this.server = httpServer;
+            this.executor = exec;
+            this.activeConfig = config;
+            plugin.getLogger().info("[EliteLogs] API listening on " + config.bind + ":" + config.port);
+        } catch (IOException | IllegalArgumentException ex) {
+            plugin.getLogger().severe("[EliteLogs] Failed to start API server: " + ex.getMessage());
+            this.activeConfig = config;
+            stopServer();
+        }
+    }
+
+    private void stopServer() {
+        HttpServer httpServer = this.server;
+        if (httpServer != null) {
+            httpServer.stop(0);
+            this.server = null;
+        }
+        ExecutorService exec = this.executor;
+        if (exec != null) {
+            exec.shutdownNow();
+            this.executor = null;
+        }
+    }
+
+    private void handleSafely(HttpExchange exchange, ExchangeHandler handler) {
+        try {
+            handler.handle(exchange);
+        } catch (Throwable ex) {
+            plugin.getLogger().warning("[EliteLogs] API request failed: " + ex.getMessage());
+            if (!Boolean.TRUE.equals(exchange.getAttribute(ATTR_RESPONSE_SENT))) {
+                try {
+                    sendError(exchange, 500, "Internal server error");
+                } catch (IOException ignored) {
+                }
+            }
+        } finally {
+            exchange.close();
+        }
+    }
+
+    private void handleStatus(HttpExchange exchange) throws IOException {
+        if (!requireGet(exchange) || !authenticate(exchange)) {
+            return;
+        }
+        ApiConfig config = this.activeConfig;
+        StringBuilder json = new StringBuilder();
+        json.append('{');
+        json.append("\"plugin\":{");
+        json.append("\"name\":").append(JsonUtil.quote(plugin.getDescription().getName())).append(',');
+        json.append("\"version\":").append(JsonUtil.quote(plugin.getDescription().getVersion())).append('}');
+        json.append(',');
+
+        json.append("\"server\":{");
+        json.append("\"version\":").append(JsonUtil.quote(ServerCompat.describeServerVersion())).append(',');
+        json.append("\"supportedRange\":").append(JsonUtil.quote(ServerCompat.describeSupportedRange())).append(',');
+        json.append("\"onlinePlayers\":").append(ServerCompat.getOnlinePlayerCount());
+        json.append('}');
+        json.append(',');
+
+        json.append("\"config\":{");
+        json.append("\"language\":").append(JsonUtil.quote(plugin.getConfig().getString("language", "en"))).append(',');
+        json.append("\"debug\":").append(plugin.getConfig().getBoolean("debug", false)).append(',');
+        json.append("\"logs\":{");
+        json.append("\"splitByPlayer\":").append(plugin.getConfig().getBoolean("logs.split-by-player", true));
+        ConfigurationSection logsSection = plugin.getConfig().getConfigurationSection("logs.types");
+        if (logsSection != null) {
+            List<String> keys = new ArrayList<>(logsSection.getKeys(false));
+            Collections.sort(keys);
+            if (!keys.isEmpty()) {
+                json.append(',');
+                json.append("\"categories\":{");
+                for (int i = 0; i < keys.size(); i++) {
+                    String key = keys.get(i);
+                    json.append(JsonUtil.quote(key)).append(':').append(logsSection.getBoolean(key, true));
+                    if (i + 1 < keys.size()) {
+                        json.append(',');
+                    }
+                }
+                json.append('}');
+            }
+        }
+        json.append('}');
+        json.append(',');
+
+        json.append("\"sessions\":{");
+        json.append("\"enabled\":").append(plugin.getConfig().getBoolean("sessions.enabled", true)).append(',');
+        json.append("\"autosaveMinutes\":").append(plugin.getConfig().getInt("sessions.autosave-minutes", 10)).append(',');
+        json.append("\"saveGlobal\":").append(plugin.getConfig().getBoolean("sessions.save-global", true)).append(',');
+        json.append("\"savePlayers\":").append(plugin.getConfig().getBoolean("sessions.save-players", true));
+        json.append('}');
+        json.append(',');
+
+        json.append("\"metrics\":{");
+        json.append("\"enabled\":").append(plugin.getConfig().getBoolean("metrics.enabled", true)).append(',');
+        json.append("\"intervalSeconds\":").append(plugin.getConfig().getInt("metrics.interval-seconds", 60));
+        json.append('}');
+        json.append(',');
+
+        json.append("\"watchdog\":{");
+        json.append("\"enabled\":").append(plugin.getConfig().getBoolean("watchdog.enabled", true)).append(',');
+        json.append("\"tpsThreshold\":").append(plugin.getConfig().getDouble("watchdog.tps-threshold", 5.0)).append(',');
+        json.append("\"errorThreshold\":").append(plugin.getConfig().getInt("watchdog.error-threshold", 50));
+        json.append('}');
+        json.append(',');
+
+        json.append("\"api\":{");
+        boolean running = server != null;
+        json.append("\"enabled\":").append(running).append(',');
+        json.append("\"bind\":").append(JsonUtil.quote(config != null ? config.bind : plugin.getConfig().getString("api.bind", "127.0.0.1"))).append(',');
+        json.append("\"port\":").append(config != null ? config.port : plugin.getConfig().getInt("api.port", 9173)).append(',');
+        json.append("\"requiresAuth\":").append(config != null && config.token != null).append(',');
+        json.append("\"logHistory\":").append(logBuffer.getCapacity());
+        json.append('}');
+        json.append('}');
+
+        markResponded(exchange);
+        JsonResponse.send(exchange, 200, json.toString());
+    }
+
+    private void handleMetrics(HttpExchange exchange) throws IOException {
+        if (!requireGet(exchange) || !authenticate(exchange)) {
+            return;
+        }
+        StringBuilder json = new StringBuilder();
+        json.append('{');
+        double tps = metricsCollector != null ? metricsCollector.getCurrentTPS() : 0.0;
+        double cpu = metricsCollector != null ? metricsCollector.getCpuLoadPercent() : 0.0;
+        long heapUsed = metricsCollector != null ? metricsCollector.getHeapUsedMB() : 0L;
+        long heapMax = metricsCollector != null ? metricsCollector.getHeapMaxMB() : 0L;
+        json.append("\"tps\":").append(String.format(java.util.Locale.ROOT, "%.2f", tps)).append(',');
+        json.append("\"cpuLoad\":").append(String.format(java.util.Locale.ROOT, "%.1f", cpu)).append(',');
+        json.append("\"heapUsedMB\":").append(heapUsed).append(',');
+        json.append("\"heapMaxMB\":").append(heapMax).append(',');
+        json.append("\"onlinePlayers\":").append(ServerCompat.getOnlinePlayerCount()).append(',');
+
+        json.append("\"session\":{");
+        boolean running = sessionManager != null && sessionManager.isRunning();
+        json.append("\"running\":").append(running).append(',');
+        long startedAt = sessionManager != null ? sessionManager.getSessionStartMillis() : 0L;
+        json.append("\"startedAt\":").append(startedAt).append(',');
+        long uptime = sessionManager != null ? sessionManager.getUptimeSeconds() : 0L;
+        json.append("\"uptimeSeconds\":").append(uptime).append(',');
+        int joins = sessionManager != null ? sessionManager.getJoinCount() : 0;
+        int warns = sessionManager != null ? sessionManager.getWarnCount() : 0;
+        int errors = sessionManager != null ? sessionManager.getErrorCount() : 0;
+        json.append("\"joins\":").append(joins).append(',');
+        json.append("\"warns\":").append(warns).append(',');
+        json.append("\"errors\":").append(errors);
+        json.append('}');
+        json.append(',');
+
+        json.append("\"watchdog\":{");
+        json.append("\"enabled\":").append(plugin.getConfig().getBoolean("watchdog.enabled", true)).append(',');
+        json.append("\"tpsThreshold\":").append(plugin.getConfig().getDouble("watchdog.tps-threshold", 5.0)).append(',');
+        json.append("\"errorThreshold\":").append(plugin.getConfig().getInt("watchdog.error-threshold", 50));
+        json.append('}');
+        json.append('}');
+
+        markResponded(exchange);
+        JsonResponse.send(exchange, 200, json.toString());
+    }
+
+    private void handleLogs(HttpExchange exchange) throws IOException {
+        if (!requireGet(exchange) || !authenticate(exchange)) {
+            return;
+        }
+        String path = exchange.getRequestURI().getPath();
+        if (path == null) {
+            sendError(exchange, 404, "Not found");
+            return;
+        }
+        if (path.equals("/api/v1/logs") || path.equals("/api/v1/logs/")) {
+            List<String> categories = new ArrayList<>(logBuffer.getCategories());
+            categories.sort(Comparator.naturalOrder());
+            StringBuilder json = new StringBuilder();
+            json.append('{');
+            json.append("\"categories\":[");
+            for (int i = 0; i < categories.size(); i++) {
+                json.append(JsonUtil.quote(categories.get(i)));
+                if (i + 1 < categories.size()) {
+                    json.append(',');
+                }
+            }
+            json.append(']');
+            json.append('}');
+            markResponded(exchange);
+            JsonResponse.send(exchange, 200, json.toString());
+            return;
+        }
+
+        if (!path.startsWith("/api/v1/logs/")) {
+            sendError(exchange, 404, "Not found");
+            return;
+        }
+        String encoded = path.substring("/api/v1/logs/".length());
+        if (encoded.isEmpty()) {
+            sendError(exchange, 404, "Not found");
+            return;
+        }
+        String category = urlDecode(encoded);
+        int limit = parseLimit(exchange.getRequestURI().getRawQuery(), logBuffer.getCapacity());
+        limit = Math.max(1, Math.min(limit, logBuffer.getCapacity()));
+        List<String> lines = logBuffer.getRecent(category, limit);
+        StringBuilder json = new StringBuilder();
+        json.append('{');
+        json.append("\"category\":").append(JsonUtil.quote(category)).append(',');
+        json.append("\"limit\":").append(limit).append(',');
+        json.append("\"size\":").append(lines.size()).append(',');
+        json.append("\"lines\":[");
+        for (int i = 0; i < lines.size(); i++) {
+            json.append(JsonUtil.quote(lines.get(i)));
+            if (i + 1 < lines.size()) {
+                json.append(',');
+            }
+        }
+        json.append(']');
+        json.append('}');
+        markResponded(exchange);
+        JsonResponse.send(exchange, 200, json.toString());
+    }
+
+    private int parseLimit(String rawQuery, int fallback) {
+        if (rawQuery == null || rawQuery.isEmpty()) {
+            return fallback;
+        }
+        StringTokenizer tokenizer = new StringTokenizer(rawQuery, "&");
+        while (tokenizer.hasMoreTokens()) {
+            String token = tokenizer.nextToken();
+            int eq = token.indexOf('=');
+            if (eq <= 0) {
+                continue;
+            }
+            String key = token.substring(0, eq);
+            if (!"limit".equals(key)) {
+                continue;
+            }
+            String value = token.substring(eq + 1);
+            try {
+                return Integer.parseInt(urlDecode(value));
+            } catch (IllegalArgumentException ignored) {
+                return fallback;
+            }
+        }
+        return fallback;
+    }
+
+    private String urlDecode(String value) {
+        try {
+            return URLDecoder.decode(value, StandardCharsets.UTF_8.name());
+        } catch (UnsupportedEncodingException ex) {
+            throw new IllegalStateException("UTF-8 not supported", ex);
+        }
+    }
+
+    private boolean requireGet(HttpExchange exchange) throws IOException {
+        if (!"GET".equalsIgnoreCase(exchange.getRequestMethod())) {
+            exchange.getResponseHeaders().set("Allow", "GET");
+            sendError(exchange, 405, "Method not allowed");
+            return false;
+        }
+        return true;
+    }
+
+    private boolean authenticate(HttpExchange exchange) throws IOException {
+        ApiConfig config = this.activeConfig;
+        if (config == null || config.token == null) {
+            return true;
+        }
+        Headers headers = exchange.getRequestHeaders();
+        String provided = headers.getFirst("X-API-Key");
+        if (provided == null || provided.isEmpty()) {
+            provided = getQueryParam(exchange.getRequestURI().getRawQuery(), "token");
+        }
+        if (provided != null && provided.equals(config.token)) {
+            return true;
+        }
+        sendError(exchange, 401, "Unauthorized");
+        return false;
+    }
+
+    private String getQueryParam(String rawQuery, String name) {
+        if (rawQuery == null || rawQuery.isEmpty()) {
+            return null;
+        }
+        StringTokenizer tokenizer = new StringTokenizer(rawQuery, "&");
+        while (tokenizer.hasMoreTokens()) {
+            String token = tokenizer.nextToken();
+            int eq = token.indexOf('=');
+            if (eq <= 0) {
+                continue;
+            }
+            String key = token.substring(0, eq);
+            if (!name.equals(key)) {
+                continue;
+            }
+            String value = token.substring(eq + 1);
+            try {
+                return urlDecode(value);
+            } catch (IllegalArgumentException ignored) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    private void sendError(HttpExchange exchange, int status, String message) throws IOException {
+        markResponded(exchange);
+        JsonResponse.send(exchange, status, "{\"error\":" + JsonUtil.quote(message) + "}");
+    }
+
+    private void markResponded(HttpExchange exchange) {
+        exchange.setAttribute(ATTR_RESPONSE_SENT, Boolean.TRUE);
+    }
+
+    private interface ExchangeHandler {
+        void handle(HttpExchange exchange) throws IOException;
+    }
+
+    private static final class ApiConfig {
+        final String bind;
+        final int port;
+        final String token;
+        final boolean enabled;
+
+        ApiConfig(String bind, int port, String token, boolean enabled) {
+            this.bind = bind;
+            this.port = port;
+            this.token = token;
+            this.enabled = enabled;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof ApiConfig)) {
+                return false;
+            }
+            ApiConfig that = (ApiConfig) o;
+            return port == that.port && enabled == that.enabled && Objects.equals(bind, that.bind) && Objects.equals(token, that.token);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(bind, port, token, enabled);
+        }
+    }
+
+    private static final class ApiThreadFactory implements ThreadFactory {
+        @Override
+        public Thread newThread(Runnable r) {
+            Thread thread = new Thread(r, "EliteLogs-Api-" + THREAD_COUNTER.incrementAndGet());
+            thread.setDaemon(true);
+            return thread;
+        }
+    }
+}

--- a/EliteLogs/src/main/java/com/elitelogs/api/JsonResponse.java
+++ b/EliteLogs/src/main/java/com/elitelogs/api/JsonResponse.java
@@ -1,0 +1,21 @@
+package com.elitelogs.api;
+
+import com.sun.net.httpserver.HttpExchange;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+
+final class JsonResponse {
+    private JsonResponse() {
+    }
+
+    static void send(HttpExchange exchange, int status, String body) throws IOException {
+        byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().set("Content-Type", "application/json; charset=utf-8");
+        exchange.sendResponseHeaders(status, bytes.length);
+        try (OutputStream os = exchange.getResponseBody()) {
+            os.write(bytes);
+        }
+    }
+}

--- a/EliteLogs/src/main/java/com/elitelogs/api/JsonUtil.java
+++ b/EliteLogs/src/main/java/com/elitelogs/api/JsonUtil.java
@@ -1,0 +1,53 @@
+package com.elitelogs.api;
+
+final class JsonUtil {
+    private JsonUtil() {
+    }
+
+    static String quote(String value) {
+        if (value == null) {
+            return "null";
+        }
+        StringBuilder sb = new StringBuilder(value.length() + 16);
+        sb.append('"');
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            switch (c) {
+                case '\\':
+                    sb.append("\\\\");
+                    break;
+                case '"':
+                    sb.append("\\\"");
+                    break;
+                case '\b':
+                    sb.append("\\b");
+                    break;
+                case '\f':
+                    sb.append("\\f");
+                    break;
+                case '\n':
+                    sb.append("\\n");
+                    break;
+                case '\r':
+                    sb.append("\\r");
+                    break;
+                case '\t':
+                    sb.append("\\t");
+                    break;
+                default:
+                    if (c < 0x20) {
+                        sb.append("\\u");
+                        String hex = Integer.toHexString(c);
+                        for (int pad = hex.length(); pad < 4; pad++) {
+                            sb.append('0');
+                        }
+                        sb.append(hex);
+                    } else {
+                        sb.append(c);
+                    }
+            }
+        }
+        sb.append('"');
+        return sb.toString();
+    }
+}

--- a/EliteLogs/src/main/java/com/elitelogs/api/JsonUtil.java
+++ b/EliteLogs/src/main/java/com/elitelogs/api/JsonUtil.java
@@ -1,5 +1,9 @@
 package com.elitelogs.api;
 
+import java.lang.reflect.Array;
+import java.util.Iterator;
+import java.util.Map;
+
 final class JsonUtil {
     private JsonUtil() {
     }
@@ -49,5 +53,117 @@ final class JsonUtil {
         }
         sb.append('"');
         return sb.toString();
+    }
+
+    static String stringify(Object value) {
+        StringBuilder sb = new StringBuilder();
+        appendJson(sb, value);
+        return sb.toString();
+    }
+
+    private static void appendJson(StringBuilder sb, Object value) {
+        if (value == null) {
+            sb.append("null");
+            return;
+        }
+        if (value instanceof String) {
+            sb.append(quote((String) value));
+            return;
+        }
+        if (value instanceof Number) {
+            appendNumber(sb, (Number) value);
+            return;
+        }
+        if (value instanceof Boolean) {
+            sb.append(((Boolean) value) ? "true" : "false");
+            return;
+        }
+        if (value instanceof Map<?, ?>) {
+            appendMap(sb, (Map<?, ?>) value);
+            return;
+        }
+        if (value instanceof Iterable<?>) {
+            appendIterable(sb, (Iterable<?>) value);
+            return;
+        }
+        Class<?> type = value.getClass();
+        if (type.isArray()) {
+            appendArray(sb, value);
+            return;
+        }
+        sb.append(quote(String.valueOf(value)));
+    }
+
+    private static void appendNumber(StringBuilder sb, Number number) {
+        if (number instanceof Double || number instanceof Float) {
+            double value = number.doubleValue();
+            if (Double.isFinite(value)) {
+                sb.append(trimTrailingZeros(Double.toString(value)));
+            } else {
+                sb.append('0');
+            }
+            return;
+        }
+        sb.append(number.toString());
+    }
+
+    private static String trimTrailingZeros(String value) {
+        int dotIndex = value.indexOf('.');
+        if (dotIndex < 0) {
+            return value;
+        }
+        int end = value.length();
+        while (end > dotIndex && value.charAt(end - 1) == '0') {
+            end--;
+        }
+        if (end > dotIndex && value.charAt(end - 1) == '.') {
+            end--;
+        }
+        return value.substring(0, end);
+    }
+
+    private static void appendMap(StringBuilder sb, Map<?, ?> map) {
+        sb.append('{');
+        boolean first = true;
+        for (Map.Entry<?, ?> entry : map.entrySet()) {
+            Object key = entry.getKey();
+            if (key == null) {
+                continue;
+            }
+            if (!first) {
+                sb.append(',');
+            }
+            first = false;
+            sb.append(quote(String.valueOf(key)));
+            sb.append(':');
+            appendJson(sb, entry.getValue());
+        }
+        sb.append('}');
+    }
+
+    private static void appendIterable(StringBuilder sb, Iterable<?> iterable) {
+        sb.append('[');
+        Iterator<?> iterator = iterable.iterator();
+        boolean first = true;
+        while (iterator.hasNext()) {
+            if (!first) {
+                sb.append(',');
+            }
+            first = false;
+            appendJson(sb, iterator.next());
+        }
+        sb.append(']');
+    }
+
+    private static void appendArray(StringBuilder sb, Object array) {
+        sb.append('[');
+        int length = Array.getLength(array);
+        for (int i = 0; i < length; i++) {
+            if (i > 0) {
+                sb.append(',');
+            }
+            appendJson(sb, Array.get(array, i));
+        }
+        sb.append(']');
     }
 }

--- a/EliteLogs/src/main/java/com/elitelogs/commands/ReloadSubcommand.java
+++ b/EliteLogs/src/main/java/com/elitelogs/commands/ReloadSubcommand.java
@@ -27,6 +27,7 @@ public class ReloadSubcommand extends AbstractSubcommand {
         lang.load();
         DiscordAlerter.init(plugin);
         router.reloadConfig();
+        plugin.reloadApi();
         sender.sendMessage(colorize(lang.get("command-reload")));
         return true;
     }

--- a/EliteLogs/src/main/java/com/elitelogs/logging/LogRouter.java
+++ b/EliteLogs/src/main/java/com/elitelogs/logging/LogRouter.java
@@ -80,6 +80,10 @@ public class LogRouter {
         if (listener != null) listeners.add(listener);
     }
 
+    public void removeListener(SinkListener listener) {
+        if (listener != null) listeners.remove(listener);
+    }
+
     public void setListener(SinkListener listener) {
         listeners.clear();
         addListener(listener);

--- a/EliteLogs/src/main/java/com/elitelogs/metrics/Watchdog.java
+++ b/EliteLogs/src/main/java/com/elitelogs/metrics/Watchdog.java
@@ -1,7 +1,9 @@
 package com.elitelogs.metrics;
 
 import com.elitelogs.EliteLogsPlugin;
+import com.elitelogs.inspector.Inspector;
 import com.elitelogs.integration.DiscordAlerter;
+import com.elitelogs.localization.Lang;
 import com.elitelogs.logging.LogRouter;
 import com.elitelogs.reporting.Exporter;
 import org.bukkit.Bukkit;
@@ -13,14 +15,30 @@ import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.Locale;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class Watchdog implements LogRouter.SinkListener {
+    public static final int SAMPLE_INTERVAL_SECONDS = 5;
+    private static final int SAMPLE_PERIOD_TICKS = SAMPLE_INTERVAL_SECONDS * 20;
+    private static final String REASON_TPS = "TPS_BELOW_THRESHOLD";
+    private static final String REASON_ERRORS = "ERRORS_ABOVE_THRESHOLD";
+
     private final EliteLogsPlugin plugin;
     private final LogRouter router;
     private final MetricsCollector metrics;
+    private final AtomicInteger errorsWindow = new AtomicInteger();
+    private final AtomicInteger triggerCount = new AtomicInteger();
+
     private BukkitTask task;
-    private AtomicInteger errorsWindow = new AtomicInteger();
+    private volatile boolean running;
+    private volatile long lastCheckMillis;
+    private volatile double lastCheckTps;
+    private volatile int lastCheckErrors;
+    private volatile long lastTriggerMillis;
+    private volatile double lastTriggerTps;
+    private volatile int lastTriggerErrors;
+    private volatile String lastTriggerReason;
 
     public Watchdog(EliteLogsPlugin plugin, LogRouter router, MetricsCollector metrics) {
         this.plugin = plugin;
@@ -29,62 +47,237 @@ public class Watchdog implements LogRouter.SinkListener {
         router.addListener(this);
     }
 
-    public void start() {
+    public synchronized void start() {
         stop();
-        int periodTicks = 20 * 5; // каждые 5 секунд
-        task = Bukkit.getScheduler().runTaskTimer(plugin, this::tick, periodTicks, periodTicks);
+        errorsWindow.set(0);
+        triggerCount.set(0);
+        lastCheckMillis = 0L;
+        lastCheckTps = 0.0;
+        lastCheckErrors = 0;
+        lastTriggerMillis = 0L;
+        lastTriggerTps = 0.0;
+        lastTriggerErrors = 0;
+        lastTriggerReason = null;
+        running = true;
+        task = Bukkit.getScheduler().runTaskTimer(plugin, this::tick, SAMPLE_PERIOD_TICKS, SAMPLE_PERIOD_TICKS);
     }
 
-    public void stop() {
-        if (task != null) task.cancel();
+    public synchronized void stop() {
+        running = false;
+        if (task != null) {
+            task.cancel();
+            task = null;
+        }
+        errorsWindow.set(0);
+    }
+
+    public boolean isRunning() {
+        return running;
     }
 
     private void tick() {
-        double tps = metrics.getCurrentTPS();
+        if (!running) {
+            return;
+        }
+        double tps = metrics != null ? metrics.getCurrentTPS() : 0.0;
         int errorThreshold = plugin.getConfig().getInt("watchdog.error-threshold", 50);
         double tpsThreshold = plugin.getConfig().getDouble("watchdog.tps-threshold", 5.0);
         int errorCount = errorsWindow.getAndSet(0);
 
-        if (tps < tpsThreshold || errorCount > errorThreshold) {
-            String triggerLine = "[Watchdog] Triggered: TPS=" + tps + " errors/5s=" + errorCount;
-            router.warn(triggerLine);
-            router.console(triggerLine);
+        long now = System.currentTimeMillis();
+        lastCheckMillis = now;
+        lastCheckTps = tps;
+        lastCheckErrors = errorCount;
 
-            if (plugin.getConfig().getBoolean("watchdog.actions.run-inspector", true)) {
-                // можно дернуть инспектор командой или API - здесь оставлен хук
+        boolean tpsLow = tps < tpsThreshold;
+        boolean tooManyErrors = errorCount > errorThreshold;
+        if (!tpsLow && !tooManyErrors) {
+            return;
+        }
+
+        lastTriggerMillis = now;
+        lastTriggerTps = tps;
+        lastTriggerErrors = errorCount;
+        String reason = buildReason(tpsLow, tooManyErrors);
+        lastTriggerReason = reason;
+        triggerCount.incrementAndGet();
+
+        executeTriggerActions(tps, errorCount, reason);
+    }
+
+    private String buildReason(boolean tpsLow, boolean tooManyErrors) {
+        if (tpsLow && tooManyErrors) {
+            return REASON_TPS + "+" + REASON_ERRORS;
+        }
+        if (tpsLow) {
+            return REASON_TPS;
+        }
+        if (tooManyErrors) {
+            return REASON_ERRORS;
+        }
+        return null;
+    }
+
+    private void executeTriggerActions(double tps, int errorCount, String reason) {
+        String suffix = reason != null ? " (" + reason + ")" : "";
+        String triggerLine = String.format(Locale.ROOT, "[Watchdog] Triggered%s: TPS=%.2f errors/%ds=%d",
+                suffix, tps, SAMPLE_INTERVAL_SECONDS, errorCount);
+        router.warn(triggerLine);
+        router.console(triggerLine);
+
+        if (plugin.getConfig().getBoolean("watchdog.actions.run-inspector", true)) {
+            runInspectorAsync();
+        }
+
+        if (plugin.getConfig().getBoolean("watchdog.actions.create-crash-report", true)) {
+            prepareCrashReport();
+        }
+    }
+
+    private void runInspectorAsync() {
+        Bukkit.getScheduler().runTask(plugin, () -> {
+            try {
+                Inspector inspector = plugin.inspector();
+                if (inspector != null) {
+                    inspector.runAll();
+                    return;
+                }
+                Lang lang = plugin.lang();
+                if (lang != null) {
+                    new Inspector(plugin, lang).runAll();
+                } else {
+                    router.warn("[Watchdog] Failed to run inspector: language bundle not ready");
+                }
+            } catch (Throwable t) {
+                router.warn("[Watchdog] Failed to run inspector: " + t.getMessage());
             }
+        });
+    }
 
-            if (plugin.getConfig().getBoolean("watchdog.actions.create-crash-report", true)) {
-                String ts = new SimpleDateFormat("yyyyMMdd-HHmmss").format(new Date());
-                File crashTarget = new File(plugin.getDataFolder(),
-                        "exports/inspector-report-CRASH-" + ts + ".zip");
+    private void prepareCrashReport() {
+        String ts = new SimpleDateFormat("yyyyMMdd-HHmmss").format(new Date());
+        File crashTarget = new File(plugin.getDataFolder(),
+                "exports/inspector-report-CRASH-" + ts + ".zip");
+        try {
+            File exported = Exporter.exportToday(plugin.getDataFolder());
+            File finalFile = exported;
+            if (!exported.equals(crashTarget)) {
                 try {
-                    File exported = Exporter.exportToday(plugin.getDataFolder());
-                    File finalFile = exported;
-                    if (!exported.equals(crashTarget)) {
-                        try {
-                            Files.createDirectories(crashTarget.toPath().getParent());
-                            Files.move(exported.toPath(), crashTarget.toPath(), StandardCopyOption.REPLACE_EXISTING);
-                            finalFile = crashTarget;
-                        } catch (IOException moveError) {
-                            router.warn("[Watchdog] Failed to rename crash report to " + crashTarget.getName() + ": " + moveError.getMessage());
-                        }
-                    }
-                    String crashLine = "[Watchdog] Crash report prepared: " + finalFile.getAbsolutePath();
-                    router.warn(crashLine);
-                    router.console(crashLine);
-                    if (plugin.getConfig().getBoolean("watchdog.actions.discord-alert", true)) {
-                        DiscordAlerter.maybeSend("watchdog", "Crash report prepared: " + finalFile.getName());
-                    }
-                } catch (IOException e) {
-                    router.error("[Watchdog] Export failed: " + e.getMessage());
+                    Files.createDirectories(crashTarget.toPath().getParent());
+                    Files.move(exported.toPath(), crashTarget.toPath(), StandardCopyOption.REPLACE_EXISTING);
+                    finalFile = crashTarget;
+                } catch (IOException moveError) {
+                    router.warn("[Watchdog] Failed to rename crash report to " + crashTarget.getName() + ": " + moveError.getMessage());
                 }
             }
+            String crashLine = "[Watchdog] Crash report prepared: " + finalFile.getAbsolutePath();
+            router.warn(crashLine);
+            router.console(crashLine);
+            if (plugin.getConfig().getBoolean("watchdog.actions.discord-alert", true)) {
+                DiscordAlerter.maybeSend("watchdog", "Crash report prepared: " + finalFile.getName());
+            }
+        } catch (IOException e) {
+            router.error("[Watchdog] Export failed: " + e.getMessage());
         }
+    }
+
+    public WatchdogSnapshot snapshot() {
+        return new WatchdogSnapshot(
+                running,
+                SAMPLE_INTERVAL_SECONDS,
+                lastCheckMillis,
+                lastCheckTps,
+                lastCheckErrors,
+                lastTriggerMillis,
+                lastTriggerTps,
+                lastTriggerErrors,
+                lastTriggerReason,
+                triggerCount.get(),
+                errorsWindow.get()
+        );
     }
 
     @Override
     public void onLogged(String category, String line) {
-        if ("errors".equals(category)) errorsWindow.incrementAndGet();
+        if (!running) {
+            return;
+        }
+        if ("errors".equals(category)) {
+            errorsWindow.incrementAndGet();
+        }
+    }
+
+    public static final class WatchdogSnapshot {
+        private final boolean running;
+        private final int intervalSeconds;
+        private final long lastCheckMillis;
+        private final double lastCheckTps;
+        private final int lastCheckErrors;
+        private final long lastTriggerMillis;
+        private final double lastTriggerTps;
+        private final int lastTriggerErrors;
+        private final String lastTriggerReason;
+        private final int triggerCount;
+        private final int pendingErrors;
+
+        private WatchdogSnapshot(boolean running, int intervalSeconds, long lastCheckMillis, double lastCheckTps,
+                                 int lastCheckErrors, long lastTriggerMillis, double lastTriggerTps,
+                                 int lastTriggerErrors, String lastTriggerReason, int triggerCount, int pendingErrors) {
+            this.running = running;
+            this.intervalSeconds = intervalSeconds;
+            this.lastCheckMillis = lastCheckMillis;
+            this.lastCheckTps = lastCheckTps;
+            this.lastCheckErrors = lastCheckErrors;
+            this.lastTriggerMillis = lastTriggerMillis;
+            this.lastTriggerTps = lastTriggerTps;
+            this.lastTriggerErrors = lastTriggerErrors;
+            this.lastTriggerReason = lastTriggerReason;
+            this.triggerCount = triggerCount;
+            this.pendingErrors = pendingErrors;
+        }
+
+        public boolean isRunning() {
+            return running;
+        }
+
+        public int getIntervalSeconds() {
+            return intervalSeconds;
+        }
+
+        public long getLastCheckMillis() {
+            return lastCheckMillis;
+        }
+
+        public double getLastCheckTps() {
+            return lastCheckTps;
+        }
+
+        public int getLastCheckErrors() {
+            return lastCheckErrors;
+        }
+
+        public long getLastTriggerMillis() {
+            return lastTriggerMillis;
+        }
+
+        public double getLastTriggerTps() {
+            return lastTriggerTps;
+        }
+
+        public int getLastTriggerErrors() {
+            return lastTriggerErrors;
+        }
+
+        public String getLastTriggerReason() {
+            return lastTriggerReason;
+        }
+
+        public int getTriggerCount() {
+            return triggerCount;
+        }
+
+        public int getPendingErrors() {
+            return pendingErrors;
+        }
     }
 }

--- a/EliteLogs/src/main/java/com/elitelogs/reporting/SessionManager.java
+++ b/EliteLogs/src/main/java/com/elitelogs/reporting/SessionManager.java
@@ -22,7 +22,7 @@ import java.util.logging.Level;
 public class SessionManager implements LogRouter.SinkListener {
     private final Plugin plugin;
     private final LogRouter router;
-    private long start;
+    private volatile long start;
     private AtomicInteger warns = new AtomicInteger();
     private AtomicInteger errors = new AtomicInteger();
     private AtomicInteger joins = new AtomicInteger();
@@ -146,6 +146,34 @@ public class SessionManager implements LogRouter.SinkListener {
 
     public void forceSnapshot() {
         save(false);
+    }
+
+    public long getSessionStartMillis() {
+        return start;
+    }
+
+    public long getUptimeSeconds() {
+        long startedAt = this.start;
+        if (startedAt == 0L) {
+            return 0L;
+        }
+        long now = System.currentTimeMillis();
+        if (now < startedAt) {
+            return 0L;
+        }
+        return (now - startedAt) / 1000L;
+    }
+
+    public int getWarnCount() {
+        return warns.get();
+    }
+
+    public int getErrorCount() {
+        return errors.get();
+    }
+
+    public int getJoinCount() {
+        return joins.get();
     }
 
     private static final class SessionSnapshot {

--- a/EliteLogs/src/main/resources/config.yml
+++ b/EliteLogs/src/main/resources/config.yml
@@ -97,6 +97,15 @@ metrics:
   enabled: true
   interval-seconds: 60
 
+# ── HTTP API ───────────────────────────────────────────────────────────────────
+# Expose recent logs, metrics, and session data for the web dashboard.
+api:
+  enabled: false
+  bind: "127.0.0.1"
+  port: 9173
+  auth-token: ""
+  log-history: 250
+
 # ── Chat suppressor ────────────────────────────────────────────────────────────
 # Filters spam by caching recent messages. mode can be "blacklist" or
 # "whitelist"; filters accepts regex entries.

--- a/EliteLogs/src/main/resources/plugin.yml
+++ b/EliteLogs/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: EliteLogs
 main: com.elitelogs.EliteLogsPlugin
-version: 1.1.0
+version: 1.2
 author: Elite
 commands:
   elitelogs:

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@
 - Session reports for both server and players, stored separately for better tracking.
 - Discord integration: send errors, warnings, sessions, and watchdog alerts directly to your channel.
 - Inspector, metrics, suppressor, and watchdog subsystems included out of the box.
+- Watchdog can auto-run the inspector, prepare crash reports, and now exposes its full runtime state via the HTTP API.
 - Lightweight HTTP API exposes live metrics and recent logs for external dashboards.
 - Legacy mode available for flat player log files, if you miss the old days.
 - Built-in localization packs (EN, RU, DE, FR, ES) with graceful English fallback for missing keys.
@@ -74,6 +75,7 @@ EliteLogs ships with an optional HTTP server so your SsilensioWeb admin panel (o
 ### Endpoints
 - `GET /api/v1/status` — plugin version, enabled modules, and configuration flags.
 - `GET /api/v1/metrics` — live TPS/CPU/memory plus the active session counters and watchdog thresholds.
+- `GET /api/v1/watchdog` — watchdog thresholds, trigger timings, error counters, and the most recent trigger reason.
 - `GET /api/v1/logs` — list of log categories currently buffered in memory.
 - `GET /api/v1/logs/<category>?limit=100` — most recent lines for a category (limit defaults to the configured `log-history`).
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@
 - Session reports for both server and players, stored separately for better tracking.
 - Discord integration: send errors, warnings, sessions, and watchdog alerts directly to your channel.
 - Inspector, metrics, suppressor, and watchdog subsystems included out of the box.
+- Lightweight HTTP API exposes live metrics and recent logs for external dashboards.
 - Legacy mode available for flat player log files, if you miss the old days.
 - Built-in localization packs (EN, RU, DE, FR, ES) with graceful English fallback for missing keys.
 - Written with more caffeine than code — but stable enough to trust your server with.
@@ -62,13 +63,29 @@
 ## 🗺️ Roadmap
 - [x] Add Warn & Reports logging  
 - [ ] Database support  
-- [ ] Fancy web panel (because who doesn’t love dashboards)  
-- [ ] Maybe AI log summarizer (so ChatGPT can tell you who’s sus)  
+- [ ] Fancy web panel (because who doesn’t love dashboards)
+- [ ] Maybe AI log summarizer (so ChatGPT can tell you who’s sus)
+
+---
+
+## 🔌 HTTP API
+EliteLogs ships with an optional HTTP server so your SsilensioWeb admin panel (or any other dashboard) can pull data straight from the plugin. Enable it by flipping the `api.enabled` flag in `config.yml` and adjusting the bind address/port if needed.
+
+### Endpoints
+- `GET /api/v1/status` — plugin version, enabled modules, and configuration flags.
+- `GET /api/v1/metrics` — live TPS/CPU/memory plus the active session counters and watchdog thresholds.
+- `GET /api/v1/logs` — list of log categories currently buffered in memory.
+- `GET /api/v1/logs/<category>?limit=100` — most recent lines for a category (limit defaults to the configured `log-history`).
+
+### Authentication
+- Leave `auth-token` empty for open access, or set a string and pass it as the `X-API-Key` header (or `token` query parameter).
+- `log-history` controls how many lines are cached per category for instant API responses.
+- Bind the server to `127.0.0.1` when using a reverse proxy; use `0.0.0.0` only if you really want to expose it publicly.
 
 ---
 
 ## 🤝 Contributing
-Wanna vibe-code with me?  
+Wanna vibe-code with me?
 
 1. Fork this repo  
 2. Create a new branch (`git checkout -b feature/your-idea`)  
@@ -176,6 +193,14 @@ inspector:
 metrics:
   enabled: true
   interval-seconds: 60
+
+# HTTP API (for dashboards)
+api:
+  enabled: false
+  bind: "127.0.0.1"
+  port: 9173
+  auth-token: ""
+  log-history: 250
 
 # Message suppressor / spam filter
 suppressor:


### PR DESCRIPTION
## Summary
- add an embedded HTTP API server that exposes status, metrics, and log endpoints for SsilensioWeb
- buffer recent log lines in memory and surface session/metrics data needed by the dashboard
- document and surface configuration knobs for the new API section in config.yml and the README

## Testing
- mvn -q package

------
https://chatgpt.com/codex/tasks/task_e_68cfc38ac1a08320af8e974c6b7b4fa7